### PR TITLE
Hamlの導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,3 +51,5 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+gem 'haml-rails'


### PR DESCRIPTION
# What
railsのGemfileへhaml-railsと記述後、bundle installコマンドを実行してインストールすることで、chat-spaceへHamlを導入した。

# Why
より簡単にHTMLが記述できるようになるため。