### PR TITLE
チャット画面の自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,7 +1,31 @@
 $(function(){
+
+  var reloadMessages = function() {
+    var last_message_id = $('.message:last').data("message-id");
+    $.ajax({
+      url: 'api/messages',
+      type: 'get',
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      if (messages.length !== 0) {
+        var insertHTML= '';
+        $.each(messages, function(i, message) {
+          insertHTML += buildHTML(message)
+        });
+        $('.messages').append(insertHTML);
+        $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight});
+      }
+    })
+    .fall(function() {
+      alert('error');
+    });
+  };
+
   function buildHTML(message){
     if (message.image) {
-      var html = `<div class="message">
+      var html = `<div class="message" data-message-id=${message.id}>
                             <div class="upper-info">
                               <p class="upper-info__talker">
                               ${message.user_name}
@@ -16,7 +40,7 @@ $(function(){
                             <img class="lower-info__image" src=${message.image}>
                           </div>`
     } else {
-      var html = `<div class="message">
+      var html = `<div class="message" data-message-id=${message.id}>
                             <div class="upper-info">
                               <p class="upper-info__talker">
                               ${message.user_name}
@@ -58,4 +82,7 @@ $(function(){
       $('.submit-btn').prop('disabled', false);
   });
   });
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > (?)", last_message_id)
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image_url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{data: {message: {id: message.id}}}
   .upper-info
     %p.upper-info__talker
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.user_name @message.user.name
 json.created_at @message.created_at.strftime('%Y年%m月%d日 %H時%M分')
 json.content @message.content
 json.image @message.image_url
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:index, :new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
# What
グループのメッセージへ遷移すると、7秒ごとに画面が自動更新される機能を実装した。

# Why
本アプリケーションはグループごとにチャットすることが目的だが、
現状複数人で利用する場合、投稿者以外はページを手動でリロードする必要があるため。
7秒ごとに自動更新される機能を実装することで、手動でリロードする手間を省いた。